### PR TITLE
Remove reference to missing file dist/cli.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "version": "0.1.0",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
-  "bin": "dist/cli.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "prebuild": "del dist/",


### PR DESCRIPTION
This was breaking package installation with the following error:

```
npm ERR! code ENOENT
npm ERR! syscall chmod
npm ERR! path /home/jacob/workspace/curvewise/frontend/apps/4dviz/node_modules/hyla/dist/cli.js
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, chmod '/home/jacob/workspace/curvewise/frontend/apps/4dviz/node_modules/hyla/dist/cli.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
```